### PR TITLE
Update CSE 220 to Ubuntu 22.04

### DIFF
--- a/dockerfiles/Dockerfile_cse_220
+++ b/dockerfiles/Dockerfile_cse_220
@@ -1,63 +1,15 @@
-LABEL org.opencontainers.image.authors="Ethan Blanton, David Dobmeier <daviddob@buffalo.edu>"
-FROM ubuntu:20.04
+LABEL org.opencontainers.image.authors="Ethan Blanton <eblanton@buffalo.edu>"
+FROM ubuntu:22.04
 
-#C++ Setup
-RUN apt-get update
+RUN apt-get update --fix-missing
+
 RUN apt-get install -y gcc
 RUN apt-get install -y make
-RUN apt-get install -y build-essential
-RUN apt-get install -y libcunit1-dev libcunit1-doc libcunit1 curl
-
-#Python Setup
-RUN apt-get update --fix-missing && \
-    DEBIAN_FRONTEND=nointeractive apt-get install -y python2 python-nose pep8 && \
-    curl https://bootstrap.pypa.io/get-pip.py --output get-pip.py && \
-    python2 get-pip.py && pip install --upgrade setuptools numpy pandas sphinx && \
-    ln -s /usr/bin/python2 /usr/bin/python && DEBIAN_FRONTEND=nointeractive \
-    apt-get install -y python3 python3-numpy \
-    python3-nose python3-pandas python3-pip
-
-#Java Setup
-RUN apt-get update --fix-missing
-RUN apt-get install -y default-jdk
-
-#Valgrind Setup
-RUN apt-get update
+RUN apt-get install -y git
+RUN apt-get install -y libncurses-dev
 RUN apt-get install -y valgrind
-
-#SML Setup
-RUN mkdir -p /usr/local/bin/sml
-WORKDIR /usr/local/bin/sml
-RUN apt-get install -y gcc-multilib g++-multilib lib32z1 lib32ncurses5-dev wget
-RUN wget http://www.smlnj.org/dist/working/110.78/config.tgz
-RUN tar -xzvf config.tgz
-RUN config/install.sh
-RUN ln -s /usr/local/bin/sml/bin/sml /usr/local/sbin/sml
-RUN ln -s /usr/local/bin/sml/bin/ml-lex /usr/local/sbin/ml-lex
-RUN ln -s /usr/local/bin/sml/bin/ml-yacc /usr/local/sbin/ml-yacc
-
-#Flex setup
-RUN apt-get install -y flex
-
-#Bison Setup
-RUN apt-get install -y bison
-
-#Utility setup
-RUN apt-get install -y unzip
-
-#NodeJS setup
-RUN apt-get update --fix-missing
-RUN apt-get install -y nodejs
-RUN apt-get install -y npm
-
-#OCaml Setup
-RUN apt-get install -y ocaml
-
-#Golang Setup
-RUN apt-get install -y golang
-
-#Other Utils
 RUN apt-get install -y gawk
+RUN apt-get install -y python3
 
 # Install autodriver
 WORKDIR /home
@@ -83,6 +35,4 @@ RUN rm -rf Tango/
 # Check installation
 RUN ls -l /home
 RUN which autodriver
-RUN which javac
-RUN which sml
-RUN g++ --version
+RUN gcc --version

--- a/dockerfiles/Dockerfile_cse_220
+++ b/dockerfiles/Dockerfile_cse_220
@@ -1,5 +1,5 @@
-LABEL org.opencontainers.image.authors="Ethan Blanton <eblanton@buffalo.edu>"
 FROM ubuntu:22.04
+LABEL org.opencontainers.image.authors="Ethan Blanton <eblanton@buffalo.edu>"
 
 RUN apt-get update --fix-missing
 


### PR DESCRIPTION
This also removes a bunch of stuff that was left over from when the CSE 220 image was shared with CSE 250 when 250 was in C++, and some things that appear to have been copied verbatim from the base image.